### PR TITLE
Add sqsMessenger.ready

### DIFF
--- a/lib/messenger.ts
+++ b/lib/messenger.ts
@@ -176,6 +176,19 @@ class Messenger {
       return queue.shutdown(timeout)
     })
   }
+
+  async ready(): Promise<void> {
+    await Promise.all(
+      [...Object.values(this.queueMap), ...Object.values(this.topicMap)].map(async item => {
+        if (item.isReady) {
+          return
+        }
+        return new Promise(resolve => {
+          item.on('ready', () => resolve())
+        })
+      }),
+    )
+  }
 }
 
 export default Messenger

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ruguoapp/sqs-messenger",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
在服务的 /health 里使用：

```
router.get('/health', async () => {
  await sqsMessenger.ready()
  ctx.body = {
    success: true,
  }
})
```

以确保 queue 和 topic 都是 ready 的